### PR TITLE
add Model helper class

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,6 @@ Traceback (most recent call last):
  ...
 AssertionError
 
->>> assert Foo(key='value', other_key='other_value') ==  Model(key='value')
->>> assert [Foo(key='value', other_key='other_value')] ==  List.containing(Model(key='value'))
+>>> assert Foo(key='value', other_key='other_value') == Model(key='value')
+>>> assert [Foo(key='value', other_key='other_value')] == List.containing(Model(key='value'))
 ```

--- a/README.md
+++ b/README.md
@@ -275,3 +275,23 @@ True
 >>> util.Str.not_empty() == ''
 False
 ```
+
+## Model
+Special class for comparing the equality of attrs of another object
+
+
+```python
+>>> from collections import namedtuple
+>>> Foo = namedtuple('Foo', 'id,key,other_key,parent', defaults=(None,)*4)
+
+>>> assert Foo() == Model()
+
+>>> assert Foo(key='value') == Model(key='value')
+>>> assert Foo(key='value') == Model(key='not the value')
+Traceback (most recent call last):
+ ...
+AssertionError
+
+>>> assert Foo(key='value', other_key='other_value') ==  Model(key='value')
+>>> assert [Foo(key='value', other_key='other_value')] ==  List.containing(Model(key='value'))
+```

--- a/pytest_assert_utils/util/decl.py
+++ b/pytest_assert_utils/util/decl.py
@@ -428,6 +428,7 @@ class Model:
     """Special class for comparing the equality of attrs of another object
 
     Examples of functionality:
+
     >>> from collections import namedtuple
     >>> Foo = namedtuple('Foo', 'id,key,other_key,parent', defaults=(None,)*4)
 

--- a/pytest_assert_utils/util/decl.py
+++ b/pytest_assert_utils/util/decl.py
@@ -448,4 +448,7 @@ class Model:
         self.attrs = attrs
 
     def __eq__(self, other):
-        return all(getattr(other, k, UNSET) == v for k, v in self.attrs.items())
+        try:
+            return all(getattr(other, k) == v for k, v in self.attrs.items())
+        except AttributeError:
+            return False

--- a/pytest_assert_utils/util/decl.py
+++ b/pytest_assert_utils/util/decl.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     from collections import Collection as BaseCollection
 
+from .assertions import UNSET
+
 __all__ = [
     'Any',
     'Optional',
@@ -14,6 +16,7 @@ __all__ = [
     'Set',
     'Dict',
     'Str',
+    'Model',
 ]
 
 
@@ -419,3 +422,30 @@ class Str(_CollectionValuesChecker, str, metaclass=_CollectionValuesCheckerMeta)
     False
 
     """
+
+
+class Model:
+    """Special class for comparing the equality of attrs of another object
+
+    Examples of functionality:
+    >>> from collections import namedtuple
+    >>> Foo = namedtuple('Foo', 'id,key,other_key,parent', defaults=(None,)*4)
+
+    >>> assert Foo() == Model()
+
+    >>> assert Foo(key='value') == Model(key='value')
+    >>> assert Foo(key='value') == Model(key='not the value')
+    Traceback (most recent call last):
+     ...
+    AssertionError
+
+    >>> assert Foo(key='value', other_key='other_value') ==  Model(key='value')
+    >>> assert [Foo(key='value', other_key='other_value')] ==  List.containing(Model(key='value'))
+
+    """
+
+    def __init__(self, **attrs):
+        self.attrs = attrs
+
+    def __eq__(self, other):
+        return all(getattr(other, k, UNSET) == v for k, v in self.attrs.items())

--- a/pytest_assert_utils/util/decl.py
+++ b/pytest_assert_utils/util/decl.py
@@ -440,8 +440,8 @@ class Model:
      ...
     AssertionError
 
-    >>> assert Foo(key='value', other_key='other_value') ==  Model(key='value')
-    >>> assert [Foo(key='value', other_key='other_value')] ==  List.containing(Model(key='value'))
+    >>> assert Foo(key='value', other_key='other_value') == Model(key='value')
+    >>> assert [Foo(key='value', other_key='other_value')] == List.containing(Model(key='value'))
 
     """
 


### PR DESCRIPTION
I had the need to compare model attributes within collections, so have added a helper class so you can do the following:

```
assert [Foo(key='value', other_key='other_value')] == List.containing(Model(key='value'))
```